### PR TITLE
Load xstring (#39)

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -20,6 +20,7 @@
 
 \RequireBiber[3]%
 
+\RequirePackage{xstring}%
 \RequirePackage{xparse}%
 \RequirePackage{xpatch}%
 \RequirePackage{expl3}%


### PR DESCRIPTION
Load `xstring` explicitly since `biblatex` dropped the requirement https://github.com/plk/biblatex/pull/816. See also #39.

FWIW since you already use the powerful RegExps of LaTeX3 you could consider throwing out `\IfEndWith` in favour of an `expl3` RegExp. Then you would also get rid of `xstring`.