### PR TITLE
Don't load removed l3regex package

### DIFF
--- a/latex/cbx/abnt-ibid.cbx
+++ b/latex/cbx/abnt-ibid.cbx
@@ -20,7 +20,6 @@
 \RequirePackage{xparse}%
 \RequirePackage{xpatch}%
 \RequirePackage{expl3}%
-\RequirePackage{l3regex}%
 
 % <<<1
 


### PR DESCRIPTION
This should fix https://github.com/abntex/biblatex-abnt/issues/53.