### PR TITLE
Make \bibpagerefpunct usable

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -614,7 +614,7 @@
 % titles >>>4
 
 \renewcommand*{\subtitlepunct}{\addcolon\addspace}%
-\renewcommand*{\bibpagerefpunct}{\addcomma\addspace}%
+\renewcommand*{\bibpagerefpunct}{\addperiod\space}%
 
 \DeclareFieldFormat{journaltitle}{%% >>>
   \iftoggle{ittitles}{%
@@ -1495,7 +1495,6 @@
 \renewbibmacro*{pageref}{% >>>3
   \iftoggle{backref}{%
     \iftoggle{citecount}{%
-      \printunit{\addperiod\addspace}%
       \iflistundef{pageref}{%
         \bibstring{citecountnopage}%
       }{%
@@ -1510,7 +1509,6 @@
       }%
     }{%
       \iflistundef{pageref}{}{%
-        \printunit{\addperiod\addspace}%
         \printtext{%
           \ifnumgreater{\value{pageref}}{1}{%
             \bibstring{backrefpages}\ppspace%
@@ -1582,7 +1580,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -1652,7 +1650,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -1710,7 +1708,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -1778,7 +1776,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -1840,7 +1838,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -1910,7 +1908,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -1966,7 +1964,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -2034,7 +2032,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -2096,7 +2094,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -2148,7 +2146,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -2226,7 +2224,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -2277,7 +2275,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -2345,7 +2343,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -2408,7 +2406,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -2493,7 +2491,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -2558,7 +2556,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -2610,7 +2608,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%
@@ -2681,7 +2679,7 @@
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{addendum+pubstate}%
-  \setunit*{\bibpagerefpunct}%
+  \setunit{\bibpagerefpunct}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \usebibmacro{pageref}%
   \setunit*{\addperiod\addspace}%


### PR DESCRIPTION
Currently `\bibpagerefpunct` is not usable and is essentially replaced by a hard-coded `\printunit{\addperiod\addspace}` in `pageref`. With a few changes it should be possible to get `\bibpagerefpunct` to work as expected.

Compare
```latex
\documentclass[12pt,a4paper,english]{abntex2}

\usepackage[style=abnt, backend=biber, backref=true]{biblatex}
\addbibresource{biblatex-examples.bib}

\renewcommand*{\bibpagerefpunct}{\addsemicolon\space}

\begin{document}
Citing \cite{sigfridsson}.

\printbibliography
\end{document}
```
with and without the change.

See also https://tex.stackexchange.com/q/516054/