### PR TITLE
Use \DeclareStyleSourcemap

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -273,7 +273,7 @@
   }%
 }% <<<2
 
-\DeclareSourcemap{%% >>>2
+\DeclareStyleSourcemap{%% >>>2
   % This maps some fields used in abntex2cite to biblatex fields.
   \maps[datatype=bibtex]{%
     \map{%


### PR DESCRIPTION
Styles should use `\DeclareStyleSourcemap` and not the user-level
`\DeclareSourcemap`.

See https://tex.stackexchange.com/q/516056