### PR TITLE
S. l. e s. n. em itálico e com espaço entre as letras

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -1295,19 +1295,19 @@
 
 \newbibmacro*{publisher}{%% >>>3
   \iflistundef{publisher}%
-    {\iftoggle{nosn}{}{\printtext[brackets]{\bibstring{sinenomine}}}}%
+    {\iftoggle{nosn}{}{\printtext[brackets]{\mkbibemph{\bibstring{sinenomine}}}}}%
       {\printlist{publisher}}%
 }%% <<<3
 
 \newbibmacro*{location}{%% >>>3
   \iflistundef{location}%
-    {\iftoggle{nosl}{}{\printtext[brackets]{\bibstring{sineloco}}}}%
+    {\iftoggle{nosl}{}{\printtext[brackets]{\mkbibemph{\bibstring{sineloco}}}}}%
       {\printlist{location}}%
 }%% <<<3
 
 \newbibmacro*{venue}{%% >>>3
   \iffieldundef{venue}%
-    {\iftoggle{nosl}{}{\printtext[brackets]{\bibstring{sineloco}}}}%
+    {\iftoggle{nosl}{}{\printtext[brackets]{\mkbibemph{\bibstring{sineloco}}}}}%
       {\printfield{venue}}%
 }%% <<<3
 
@@ -1328,9 +1328,9 @@
     and%
     not test {\iftoggle{nosn}}%
   }{%
-    \printtext[brackets]{\bibstring{sineloco}%
+    \printtext[brackets]{\mkbibemph{\bibstring{sineloco}}%
     \setunit{\addcolon\addnbspace}%
-    \bibstring{sinenomine}}%
+    \mkbibemph{\bibstring{sinenomine}}}%
   }{%
     \ifboolexpr{%
       test {\ifnameundef{author}}%
@@ -1385,9 +1385,9 @@
     and%
     not test {\iftoggle{nosn}}%
   }{%
-    \printtext[brackets]{\bibstring{sineloco}%
+    \printtext[brackets]{\mkbibemph{\bibstring{sineloco}}%
     \setunit{\addcolon\addnbspace}%
-    \bibstring{sinenomine}}%
+    \mkbibemph{\bibstring{sinenomine}}}%
   }{%
     \ifboolexpr{%
       test {\ifnameundef{author}}%

--- a/latex/lbx/brazilian-abnt.lbx
+++ b/latex/lbx/brazilian-abnt.lbx
@@ -69,8 +69,8 @@
   involumes    = {{in}{in}},%
   in           = {{in}{in}},%
   inseries     = {{in}{in}},%
-  sineloco     = {{sine loco}{s\adddot l\adddot}},%
-  sinenomine   = {{sine nomine}{s\adddot n\adddot}},%
+  sineloco     = {{sine loco}{s\adddot~l\adddot}},%
+  sinenomine   = {{sine nomine}{s\adddot~n\adddot}},%
   urlfrom      = {{dispon\'ivel em}{dispon\'ivel em}},%
   urlseen      = {{acesso em}{acesso em}},%
   sheet        = {{folha}{f\adddot}},%

--- a/latex/lbx/english-abnt.lbx
+++ b/latex/lbx/english-abnt.lbx
@@ -68,7 +68,7 @@
   involumes        = {{in}{in}},%
   in               = {{in}{in}},%
   inseries         = {{in}{in}},%
-  sineloco         = {{sine loco}{s\adddot l\adddot}},%
+  sineloco         = {{sine loco}{s\adddot~l\adddot}},%
   sinenomine       = {{sine nomine}{s\adddot~n\adddot}},%
   sheet            = {{sheet}{s\adddot}},%
   sheets           = {{sheets}{s\adddot}},%

--- a/latex/lbx/english-abnt.lbx
+++ b/latex/lbx/english-abnt.lbx
@@ -69,7 +69,7 @@
   in               = {{in}{in}},%
   inseries         = {{in}{in}},%
   sineloco         = {{sine loco}{s\adddot l\adddot}},%
-  sinenomine       = {{sine nomine}{s\adddot n\adddot}},%
+  sinenomine       = {{sine nomine}{s\adddot~n\adddot}},%
   sheet            = {{sheet}{s\adddot}},%
   sheets           = {{sheets}{s\adddot}},%
   illustrated      = {{illustrated}{il\adddot}},%

--- a/latex/lbx/spanish-abnt.lbx
+++ b/latex/lbx/spanish-abnt.lbx
@@ -69,7 +69,7 @@
   in               = {{in}{in}},%
   inseries         = {{in}{in}},%
   sineloco         = {{sine loco}{s\adddot l\adddot}},%
-  sinenomine       = {{sine nomine}{s\adddot n\adddot}},%
+  sinenomine       = {{sine nomine}{s\adddot~n\adddot}},%
   urlfrom          = {{disponible en}{disponible en}},%
   urlseen          = {{acceso en}{acceso en}},%
   sheet            = {{hoja}{h\adddot}},%

--- a/latex/lbx/spanish-abnt.lbx
+++ b/latex/lbx/spanish-abnt.lbx
@@ -68,7 +68,7 @@
   involumes        = {{in}{in}},%
   in               = {{in}{in}},%
   inseries         = {{in}{in}},%
-  sineloco         = {{sine loco}{s\adddot l\adddot}},%
+  sineloco         = {{sine loco}{s\adddot~l\adddot}},%
   sinenomine       = {{sine nomine}{s\adddot~n\adddot}},%
   urlfrom          = {{disponible en}{disponible en}},%
   urlseen          = {{acceso en}{acceso en}},%


### PR DESCRIPTION
As expressões s. l. e s. n. aparecem em itálico dentro dos colchetes, nas referências. Eu também adicionei um espaço entre as letras que compõem essas siglas, que não estava aparecendo anteriormente.

s.l. -> _s. l._
s.n. -> _s. n._