### PR TITLE
Espaço entre entradas nas referências = 1 linha em branco

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -185,26 +185,29 @@
   \settoggle{extradate}{#1}}%
 % <<<2
 
-% Justify text >>>2
-\DeclareBibliographyOption{justify}[false]{%
-  % \ExecuteBibliographyOptions{block=space}%
-  \appto{\bibsetup}{%
-    \raggedright%
-  }
+% Commands that append things to \bibsetup >>>2
+% Justify text >>>3
+\newtoggle{justify}
+\DeclareBibliographyOption{justify}[true]{%
+  \settoggle{justify}{#1}%
 }%
-% <<<2
+% <<<3
 
-% apply NBR 6023 2018 spacing >>>2
-\DeclareBibliographyOption{2018spacing}[true]{%
-  \appto{\bibsetup}{%
-    \linespread{1}%
+% don't apply NBR 6023 2018 spacing >>>3
+\newtoggle{oldspacing}
+\DeclareBibliographyOption{oldspacing}[true]{%
+  \settoggle{oldspacing}{#1}%
+}%
+% <<<3
+
+\appto{\bibsetup}{%
+  \nottoggle{justify}{\raggedright}{}%
+  \nottoggle{oldspacing}{%
     \setlength{\bibitemsep}{\baselineskip}%
-  }
+    \linespread{1}%
+  }{}%
 }%
 % <<<2
-
-% this option is default from 2018 on
-\ExecuteBibliographyOptions{2018spacing}
 
 % Make it pretty >>>2
 \DeclareBibliographyOption{pretty}[true]{%

--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -46,6 +46,8 @@
 \setcounter{biburllcpenalty}{6000}%
 \setcounter{biburlucpenalty}{9000}%
 
+\setlength{\bibitemsep}{\baselineskip}
+
 % <<<1
 
 
@@ -717,8 +719,8 @@
 
 \DeclareFieldFormat{illustrated}{\addspace #1\isdot}%
 
-%\DeclareFieldFormat{url}{\bibstring{urlfrom}\addcolon\addspace<\url{#1}>}%
-\DeclareFieldFormat{url}{\bibstring{urlfrom}\addcolon\addspace \url{#1}}% remove <> em urls de acordo com abnt-6023:2018	
+% remove <> in URLs according to abnt-6023:2018
+\DeclareFieldFormat{url}{\bibstring{urlfrom}\addcolon\addspace \url{#1}}
 \DeclareFieldFormat{urldate}{\bibstring{urlseen}\addcolon\addspace #1}%
 
 \DeclareFieldFormat*{note}{\addspace #1}%

--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -39,12 +39,6 @@
 
 \InitializeBibliographyStyle{\global\undef\bbx@lasthash}%
 
-\let\origbibsetup\bibsetup%
-\appto{\bibsetup}{\raggedright%
-  \linespread{1}%
-  \setlength{\bibitemsep}{\baselineskip}%
-}%
-
 \setcounter{biburlnumpenalty}{3000}%
 \setcounter{biburllcpenalty}{6000}%
 \setcounter{biburlucpenalty}{9000}%
@@ -192,11 +186,25 @@
 % <<<2
 
 % Justify text >>>2
-\DeclareBibliographyOption{justify}[true]{%
+\DeclareBibliographyOption{justify}[false]{%
   % \ExecuteBibliographyOptions{block=space}%
-  \renewcommand*{\bibsetup}{\origbibsetup}%
+  \appto{\bibsetup}{%
+    \raggedright%
+  }
 }%
 % <<<2
+
+% apply NBR 6023 2018 spacing >>>2
+\DeclareBibliographyOption{2018spacing}[true]{%
+  \appto{\bibsetup}{%
+    \linespread{1}%
+    \setlength{\bibitemsep}{\baselineskip}%
+  }
+}%
+% <<<2
+
+% this option is default from 2018 on
+\ExecuteBibliographyOptions{2018spacing}
 
 % Make it pretty >>>2
 \DeclareBibliographyOption{pretty}[true]{%

--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -40,13 +40,14 @@
 \InitializeBibliographyStyle{\global\undef\bbx@lasthash}%
 
 \let\origbibsetup\bibsetup%
-\appto{\bibsetup}{\raggedright}%
+\appto{\bibsetup}{\raggedright%
+  \linespread{1}%
+  \setlength{\bibitemsep}{\baselineskip}%
+}%
 
 \setcounter{biburlnumpenalty}{3000}%
 \setcounter{biburllcpenalty}{6000}%
 \setcounter{biburlucpenalty}{9000}%
-
-\setlength{\bibitemsep}{\baselineskip}
 
 % <<<1
 


### PR DESCRIPTION
A NBR 6023 2018 menciona que o espaço entre duas entradas nas referências deve ser o equivalente a uma linha em branco. Eu criei isso neste pull request colocando o valor de `\bibitemsep` = `\baselineskip`.