### PR TITLE
Remove underscores dos autores repetidos nas referências

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -139,6 +139,7 @@
     \renewbibmacro*{bbx:savesubtitle}{\savefield{subtitle}{\bbx@lastsubtitle}}%
   }%
 }%
+\ExecuteBibliographyOptions{repeatfields}
 \DeclareEntryOption[boolean]{repeatfields}[true]{%
   \settoggle{repeatfields}{#1}%
 }%


### PR DESCRIPTION
A NBR 6023 2018 aposenta o uso dos travessões quando os nomes dos autores se repetem nas referências. Eu implementei essa opção setando `repeatfields=true` dentro do biblatex-abnt.