### PR TITLE
Italiciza "In" e "et al"

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -1431,6 +1431,14 @@
 
 % Misc >>>2
 
+\renewbibmacro*{andothers}{%% >>>3
+  \mkbibemph{\bibstring{andothers}}
+}%% <<<3
+
+\renewbibmacro*{in:}{%% >>>3
+  \mkbibemph{\bibstring{in}}
+}%% <<<3
+
 \renewbibmacro*{volume+number+eid}{%% >>>3
   \printfield{volume}%
   \setunit*{\addcomma\addspace}%


### PR DESCRIPTION
Mais uma alteração relacionada à NBR 6023 2018, onde "_In_" e "_et al_" devem estar em itálico.